### PR TITLE
Fix `render.yaml` typo

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,7 @@ services:
           name: piazza-db
           property: connectionString
       - key: RAILS_MASTER_KEY
-          sync: false
+        sync: false
     databases:
      - name: piazza-db
        plan: free


### PR DESCRIPTION
## What does this PR do?

Small typo in `render.yaml`
